### PR TITLE
Fix post rendering

### DIFF
--- a/lib/site/component.ex
+++ b/lib/site/component.ex
@@ -1,7 +1,22 @@
 defmodule Site.Component do
+  use Phoenix.Component
+
   defmacro __using__(_) do
     quote do
       use Phoenix.Component
+      import unquote(__MODULE__)
     end
+  end
+
+  def inner_content(%{content: content} = assigns) when is_binary(content) do
+    ~H"""
+    <%= Phoenix.HTML.raw(@content) %>
+    """
+  end
+
+  def inner_content(assigns) do
+    ~H"""
+    <%= @content %>
+    """
   end
 end

--- a/lib/site/layouts/root_layout.ex
+++ b/lib/site/layouts/root_layout.ex
@@ -22,7 +22,7 @@ defmodule Site.RootLayout do
         <link rel="stylesheet" href="/css/app.css" />
       </head>
       <body>
-        <%= @inner_content |> render() |> Phoenix.HTML.raw() %>
+        <.inner_content content={render(@inner_content)}/>
       </body>
 
       <%= if Mix.env() == :dev do %>

--- a/lib/site/layouts/single_layout.ex
+++ b/lib/site/layouts/single_layout.ex
@@ -18,9 +18,8 @@ defmodule Site.SingleLayout do
         <% end %>
       </header>
 
-      <%= @inner_content |> render() |> Phoenix.HTML.raw() %>
+      <.inner_content content={render(@inner_content)}/>
     </article>
     """
-    |> Phoenix.HTML.Safe.to_iodata()
   end
 end

--- a/lib/site/pages/home_page.ex
+++ b/lib/site/pages/home_page.ex
@@ -73,6 +73,5 @@ defmodule Site.HomePage do
       </ul>
     </main>
     """
-    |> Phoenix.HTML.Safe.to_iodata()
   end
 end

--- a/lib/site/pages/posts.ex
+++ b/lib/site/pages/posts.ex
@@ -22,6 +22,5 @@ defmodule Site.Posts do
       <% end %>
     </ul>
     """
-    |> Phoenix.HTML.Safe.to_iodata()
   end
 end


### PR DESCRIPTION
When using HEEx + a post (meaning, some HTML generated from markdown),
it attempts to render plain HTML, which HEEx protects you from. You
can't just pipe it all through "Phoenix.HTML.raw", as that seems to
crash on content that is HEEx and not a string.

Solution: create a component that branches on whether the content is a
string or not, and respond accordingly.
